### PR TITLE
Covariance and Frame_id Fixes

### DIFF
--- a/src/from_fix.cpp
+++ b/src/from_fix.cpp
@@ -129,13 +129,11 @@ static void handle_fix(const sensor_msgs::NavSatFixConstPtr fix_ptr,
   odom_msg.pose.covariance[7] = fix_ptr->position_covariance[4];
   odom_msg.pose.covariance[14] = fix_ptr->position_covariance[8];
   
-  // Do not use/trust orientation dimensions from GPS.
-  odom_msg.pose.covariance[21] = 1e6;
-  odom_msg.pose.covariance[28] = 1e6;
-  odom_msg.pose.covariance[35] = 1e6;
-
-  // Orientation of GPS is pointing upward (as far as we know).
-  odom_msg.pose.pose.orientation.w = 1;
+  // Do not use orientation dimensions from GPS.
+  // (-1 is an invalid covariance and standard ROS practice to set as invalid.)
+  odom_msg.pose.covariance[21] = -1;
+  odom_msg.pose.covariance[28] = -1;
+  odom_msg.pose.covariance[35] = -1;
 
   pub_enu.publish(odom_msg); 
 }

--- a/src/to_fix.cpp
+++ b/src/to_fix.cpp
@@ -78,6 +78,7 @@ static void handle_enu(const nav_msgs::OdometryConstPtr odom_ptr,
   // Prepare output Fix message. Copy over timestamp from source message,
   // convert radian latlon output back to degrees.
   sensor_msgs::NavSatFix fix_msg;
+  fix_msg.header.frame_id = odom_ptr->child_frame_id;
   fix_msg.header.stamp = odom_ptr->header.stamp;
   fix_msg.latitude = llh[0] * TO_DEGREES;
   fix_msg.longitude = llh[1] * TO_DEGREES;


### PR DESCRIPTION
This pull request does two things:

1) Sets covariance to -1.  The ROS convention is to have -1 for an invalid covariance.  This might break robot_pose_ekf because it handles covariance incorrectly.  Setting covariance to a large number means that measurement is valid, but not sure.

2) Allows a configurable frame_id.  The GPS global frame_id needs to be injected in this node, while the child_frame_id and NavSatFix is the frame_id of the antenna, which needs to be a child of base_link.

I'm not 100% sure of your backward compatible use cases, so let me know and I'll make sure this won't break anything for you.  For instance, if you need odom.header.frame_id === odom.child_frame_id === navsatfix.header.frame_id, we could default the 'output_frame_id' to be the empty string, and know that's a special case.
